### PR TITLE
Add initial draft of golang example

### DIFF
--- a/go/.idea/.gitignore
+++ b/go/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/go/.idea/go.iml
+++ b/go/.idea/go.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="Go" enabled="true" />
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/go/.idea/modules.xml
+++ b/go/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/go.iml" filepath="$PROJECT_DIR$/.idea/go.iml" />
+    </modules>
+  </component>
+</project>

--- a/go/.idea/vcs.xml
+++ b/go/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$/.." vcs="Git" />
+  </component>
+</project>

--- a/go/README.md
+++ b/go/README.md
@@ -55,7 +55,7 @@ func extractHeaders(ctx context.Context, r *http.Request) context.Context {
 we want to propagate and add it to the context that is passed down through the call stack. In this case we are only grabbing
 the `X-Telepresence-Id` header but we could add any others that we care about, or even all of them.
 
-In `service.go` in the `InitialUppercase` function, we create a new HTTP client:
+To make the request to `/finaluppercase`, in `service.go`, in the `InitialUppercase` function, we create a new HTTP client:
 
 ```go
 client := httptransport.NewClient(

--- a/go/README.md
+++ b/go/README.md
@@ -1,0 +1,86 @@
+# Header Forwarding Example - Go
+
+## Credit where it's due
+
+This example is built using [go-kit](https://github.com/go-kit/kit), a popular enterprise microservice framework for Go,
+and heavily leans on the [stringsvc example](https://github.com/go-kit/examples/tree/master/stringsvc2) provided by
+that project.
+
+## How the example works
+
+The service has an endpoint `/uppercase` that uppercases a string sent to it via a POST request with a JSON body.
+Internally, the service makes a second HTTP call to `/finaluppercase` which does the actual uppercasing and sends the
+new string back up the chain. To test it, you can run
+
+```shell
+$ go run *.go
+```
+
+and then make this request:
+
+```shell
+curl --request POST 'http://localhost:8080/uppercase' \
+--header 'x-telepresence-id: 1234567890' \
+--header 'Content-Type: application/json' \
+--data-raw '{
+    "s": "hello, world"
+}'
+```
+
+In the console output of the running process you'll see
+
+```
+listen=:8080 caller=logging.go:35 method=finalUppercase telepresenceHeader=1234567890
+listen=:8080 caller=logging.go:23 method=uppercase telepresenceHeader=1234567890
+```
+
+This output shows that the `x-telepresence-id` header has been propagated from your call to `/uppercase`, to the second
+endpoint `/finaluppercase`.
+
+### How it's done: context.Context
+
+The most effective way to propagate headers in Go is through a `context`. `go-kit` provides some convenience methods for
+manipulating incoming and outgoing requests. At line 30 of `main.go`, we add `httptransport.ServerBefore(extractHeaders)`
+to the stack of function calls on an incoming request. `extractHeaders` is in `context_headers.go`:
+
+```go
+func extractHeaders(ctx context.Context, r *http.Request) context.Context {
+	header := r.Header.Get("X-Telepresence-Id")
+	ctx = context.WithValue(ctx, "x-telepresence-id", header)
+	return ctx
+}
+```
+
+`ServerBefore` calls any functions passed to it before the request is passed further down the stack. So we get the header
+we want to propagate and add it to the context that is passed down through the call stack. In this case we are only grabbing
+the `X-Telepresence-Id` header but we could add any others that we care about, or even all of them.
+
+In `service.go` in the `InitialUppercase` function, we create a new HTTP client:
+
+```go
+client := httptransport.NewClient(
+		"POST",
+		u,
+		encodeRequest,
+		decodeUppercaseResponse,
+		httptransport.ClientBefore(setHeaders),
+	).Endpoint()
+```
+
+The `ClientBefore` convenience method lets us pass functions that run before a request is sent. The `setHeaders` method
+we are passing looks like
+
+```go
+func setHeaders(ctx context.Context, r *http.Request) context.Context {
+	r.Header.Set("x-telepresence-id", ctx.Value("x-telepresence-id").(string))
+	return ctx
+}
+```
+
+Similar to extracting the headers, we're setting the oen we want but could do any or all headers we want to propagate.
+
+## Summary
+
+Regardless of how your Go services are structured, the key to propagating headers is to retrieve them from the request
+as soon as possible, and attach them to a context that is passed down through your call stack. Then you can add them to
+any outgoing requests to upstream services.

--- a/go/context_headers.go
+++ b/go/context_headers.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"context"
+	"net/http"
+)
+
+func extractHeaders(ctx context.Context, r *http.Request) context.Context {
+	header := r.Header.Get("X-Telepresence-Id")
+	ctx = context.WithValue(ctx, "x-telepresence-id", header)
+	return ctx
+}
+
+func setHeaders(ctx context.Context, r *http.Request) context.Context {
+	r.Header.Set("x-telepresence-id", ctx.Value("x-telepresence-id").(string))
+	return ctx
+}

--- a/go/context_headers.go
+++ b/go/context_headers.go
@@ -5,13 +5,15 @@ import (
 	"net/http"
 )
 
+const telepresenceHeader string = "x-telepresence-id"
+
 func extractHeaders(ctx context.Context, r *http.Request) context.Context {
-	header := r.Header.Get("X-Telepresence-Id")
-	ctx = context.WithValue(ctx, "x-telepresence-id", header)
+	header := r.Header.Get(telepresenceHeader)
+	ctx = context.WithValue(ctx, telepresenceHeader, header)
 	return ctx
 }
 
 func setHeaders(ctx context.Context, r *http.Request) context.Context {
-	r.Header.Set("x-telepresence-id", ctx.Value("x-telepresence-id").(string))
+	r.Header.Set(telepresenceHeader, ctx.Value(telepresenceHeader).(string))
 	return ctx
 }

--- a/go/go.mod
+++ b/go/go.mod
@@ -1,0 +1,10 @@
+module github.com/ambassadorlabs/header-forwarding-examples
+
+go 1.19
+
+require github.com/go-kit/kit v0.12.0
+
+require (
+	github.com/go-kit/log v0.2.0 // indirect
+	github.com/go-logfmt/logfmt v0.5.1 // indirect
+)

--- a/go/go.sum
+++ b/go/go.sum
@@ -1,0 +1,6 @@
+github.com/go-kit/kit v0.12.0 h1:e4o3o3IsBfAKQh5Qbbiqyfu97Ku7jrO/JbohvztANh4=
+github.com/go-kit/kit v0.12.0/go.mod h1:lHd+EkCZPIwYItmGDDRdhinkzX2A1sj+M9biaEaizzs=
+github.com/go-kit/log v0.2.0 h1:7i2K3eKTos3Vc0enKCfnVcgHh2olr/MyfboYq7cAcFw=
+github.com/go-kit/log v0.2.0/go.mod h1:NwTd00d/i8cPZ3xOwwiv2PO5MOcx78fFErGNcVmBjv0=
+github.com/go-logfmt/logfmt v0.5.1 h1:otpy5pqBCBZ1ng9RQ0dPu4PN7ba75Y/aA+UpowDyNVA=
+github.com/go-logfmt/logfmt v0.5.1/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=

--- a/go/logging.go
+++ b/go/logging.go
@@ -22,7 +22,7 @@ func (mw logmw) InitialUppercase(ctx context.Context, s string) (output string, 
 	defer func(begin time.Time) {
 		_ = mw.logger.Log(
 			"method", "uppercase",
-			"telepresenceHeader", ctx.Value("x-telepresence-id").(string),
+			"telepresenceHeader", ctx.Value(telepresenceHeader).(string),
 		)
 	}(time.Now())
 
@@ -34,7 +34,7 @@ func (mw logmw) FinalUppercase(ctx context.Context, s string) (output string, er
 	defer func(begin time.Time) {
 		_ = mw.logger.Log(
 			"method", "finalUppercase",
-			"telepresenceHeader", ctx.Value("x-telepresence-id").(string),
+			"telepresenceHeader", ctx.Value(telepresenceHeader).(string),
 		)
 	}(time.Now())
 

--- a/go/logging.go
+++ b/go/logging.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"context"
+	"time"
+
+	"github.com/go-kit/kit/log"
+)
+
+func loggingMiddleware(logger log.Logger) ServiceMiddleware {
+	return func(next StringService) StringService {
+		return logmw{logger, next}
+	}
+}
+
+type logmw struct {
+	logger log.Logger
+	StringService
+}
+
+func (mw logmw) InitialUppercase(ctx context.Context, s string) (output string, err error) {
+	defer func(begin time.Time) {
+		_ = mw.logger.Log(
+			"method", "uppercase",
+			"telepresenceHeader", ctx.Value("x-telepresence-id").(string),
+		)
+	}(time.Now())
+
+	output, err = mw.StringService.InitialUppercase(ctx, s)
+	return
+}
+
+func (mw logmw) FinalUppercase(ctx context.Context, s string) (output string, err error) {
+	defer func(begin time.Time) {
+		_ = mw.logger.Log(
+			"method", "finalUppercase",
+			"telepresenceHeader", ctx.Value("x-telepresence-id").(string),
+		)
+	}(time.Now())
+
+	output, err = mw.StringService.FinalUppercase(ctx, s)
+	return
+}
+
+func (mw logmw) Count(ctx context.Context, s string) (n int) {
+	defer func(begin time.Time) {
+		_ = mw.logger.Log(
+			"method", "count",
+			"input", s,
+			"n", n,
+			"took", time.Since(begin),
+		)
+	}(time.Now())
+
+	n = mw.StringService.Count(ctx, s)
+	return
+}

--- a/go/main.go
+++ b/go/main.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"flag"
+	"net/http"
+	"os"
+
+	"github.com/go-kit/kit/log"
+	httptransport "github.com/go-kit/kit/transport/http"
+)
+
+func main() {
+	var (
+		listen = flag.String("listen", ":8080", "HTTP listen address")
+	)
+	flag.Parse()
+
+	var logger log.Logger
+	logger = log.NewLogfmtLogger(os.Stderr)
+	logger = log.With(logger, "listen", *listen, "caller", log.DefaultCaller)
+
+	var svc StringService
+	svc = stringService{}
+	svc = loggingMiddleware(logger)(svc)
+
+	uppercaseHandler := httptransport.NewServer(
+		makeUppercaseEndpoint(svc),
+		decodeUppercaseRequest,
+		encodeResponse,
+		httptransport.ServerBefore(extractHeaders),
+	)
+	finalUppercaseHandler := httptransport.NewServer(
+		makeFinalUppercaseEndpoint(svc),
+		decodeUppercaseRequest,
+		encodeResponse,
+		httptransport.ServerBefore(extractHeaders),
+	)
+	countHandler := httptransport.NewServer(
+		makeCountEndpoint(svc),
+		decodeCountRequest,
+		encodeResponse,
+		httptransport.ServerBefore(extractHeaders),
+	)
+
+	http.Handle("/uppercase", uppercaseHandler)
+	http.Handle("/finaluppercase", finalUppercaseHandler)
+	http.Handle("/count", countHandler)
+	logger.Log("msg", "HTTP", "addr", *listen)
+	logger.Log("err", http.ListenAndServe(*listen, nil))
+}

--- a/go/service.go
+++ b/go/service.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"context"
+	"errors"
+	httptransport "github.com/go-kit/kit/transport/http"
+	"net/url"
+	"strings"
+)
+
+// StringService provides operations on strings.
+type StringService interface {
+	InitialUppercase(context.Context, string) (string, error)
+	FinalUppercase(context.Context, string) (string, error)
+	Count(context.Context, string) int
+}
+
+type stringService struct{}
+
+func (stringService) InitialUppercase(ctx context.Context, s string) (string, error) {
+	u, _ := url.Parse("http://localhost:8080/finaluppercase")
+	client := httptransport.NewClient(
+		"POST",
+		u,
+		encodeRequest,
+		decodeUppercaseResponse,
+		httptransport.ClientBefore(setHeaders),
+	).Endpoint()
+
+	resp, err := client(ctx, uppercaseRequest{S: s})
+	if err != nil {
+		return "", err
+	}
+
+	if resp.(uppercaseResponse).Err != "" {
+		return "", errors.New(resp.(uppercaseResponse).Err)
+	}
+	return resp.(uppercaseResponse).V, nil
+}
+
+func (stringService) FinalUppercase(ctx context.Context, s string) (string, error) {
+	if s == "" {
+		return "", ErrEmpty
+	}
+	return strings.ToUpper(s), nil
+}
+
+func (stringService) Count(ctx context.Context, s string) int {
+	return len(s)
+}
+
+// ErrEmpty is returned when an input string is empty.
+var ErrEmpty = errors.New("empty string")
+
+// ServiceMiddleware is a chainable behavior modifier for StringService.
+type ServiceMiddleware func(StringService) StringService

--- a/go/transport.go
+++ b/go/transport.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/go-kit/kit/endpoint"
+)
+
+func makeUppercaseEndpoint(svc StringService) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		req := request.(uppercaseRequest)
+		v, err := svc.InitialUppercase(ctx, req.S)
+		if err != nil {
+			return uppercaseResponse{v, err.Error()}, nil
+		}
+		return uppercaseResponse{v, ""}, nil
+	}
+}
+
+func makeFinalUppercaseEndpoint(svc StringService) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		req := request.(uppercaseRequest)
+		v, err := svc.FinalUppercase(ctx, req.S)
+		if err != nil {
+			return uppercaseResponse{v, err.Error()}, nil
+		}
+		return uppercaseResponse{v, ""}, nil
+	}
+}
+
+func makeCountEndpoint(svc StringService) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		req := request.(countRequest)
+		v := svc.Count(ctx, req.S)
+		return countResponse{v}, nil
+	}
+}
+
+func decodeUppercaseRequest(_ context.Context, r *http.Request) (interface{}, error) {
+	var request uppercaseRequest
+	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+		return nil, err
+	}
+	return request, nil
+}
+
+func decodeCountRequest(ctx context.Context, r *http.Request) (interface{}, error) {
+	var request countRequest
+	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+		return nil, err
+	}
+	return request, nil
+}
+
+func decodeUppercaseResponse(_ context.Context, r *http.Response) (interface{}, error) {
+	var response uppercaseResponse
+	if err := json.NewDecoder(r.Body).Decode(&response); err != nil {
+		return nil, err
+	}
+	return response, nil
+}
+
+func encodeResponse(_ context.Context, w http.ResponseWriter, response interface{}) error {
+	return json.NewEncoder(w).Encode(response)
+}
+
+func encodeRequest(_ context.Context, r *http.Request, request interface{}) error {
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(request); err != nil {
+		return err
+	}
+	r.Body = ioutil.NopCloser(&buf)
+	return nil
+}
+
+type uppercaseRequest struct {
+	S string `json:"s"`
+}
+
+type uppercaseResponse struct {
+	V   string `json:"v"`
+	Err string `json:"err,omitempty"`
+}
+
+type countRequest struct {
+	S string `json:"s"`
+}
+
+type countResponse struct {
+	V int `json:"v"`
+}


### PR DESCRIPTION
This adds a simple service using the go-kit framework that propagates  the x-telepresence-id header down through a second call using contexts.

The README in the `/go` directory is the critical thing to review here, for clarity and fulfillment of purpose. The code works (although it's great to get validation it works on someone else's machine!). If something is not clear in the README or not effective I can update the code to match suggestions.